### PR TITLE
microcloud charm v0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,0 +1,25 @@
+name: Commits
+on:
+  - pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  commits:
+    name: Signed-off-by (DCO) and Canonical CLA signed
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Get PR Commits
+      id: 'get-pr-commits'
+      uses: tim-actions/get-pr-commits@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check that all commits are signed-off
+      uses: tim-actions/dco@master
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+
+    - name: Check if Canonical CLA signed
+      uses: canonical/has-signed-canonical-cla@v1

--- a/.github/workflows/update-libs.yml
+++ b/.github/workflows/update-libs.yml
@@ -1,0 +1,39 @@
+name: Auto-update Charm Libraries
+on:
+  # Manual trigger
+  workflow_dispatch:
+  schedule:
+    - cron: "33 22 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-lib:
+    name: Check libraries
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch charm libraries
+        run: |
+          sudo snap install charmcraft --classic
+          charmcraft fetch-lib
+
+      - name: Create a PR for local changes
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: update charm libraries"
+          committer: "Github Actions <github-actions@github.com>"
+          author: "Github Actions <github-actions@github.com>"
+          title: "Update charm libraries"
+          body: |
+            Automated action to fetch latest version of charm libraries. The branch of this PR 
+            will be wiped during the next check. Unless you really know what you're doing, you 
+            most likely don't want to push any commits to this branch.
+          branch: "chore/auto-libs"
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+venv/
+build/
+*.charm
+.tox/
+.coverage
+__pycache__/
+*.py[cod]
+.idea
+.vscode/

--- a/.jujuignore
+++ b/.jujuignore
@@ -1,0 +1,4 @@
+/venv
+*.py[cod]
+*.charm
+*/.mypy_cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+To make contributions to this charm, you'll need a working [development setup](https://juju.is/docs/sdk/dev-setup).
+
+You can create an environment for development with `tox`:
+
+```shell
+tox devenv -e integration
+source venv/bin/activate
+```
+
+## Testing
+
+This project uses `tox` for managing test environments. There are some pre-configured environments
+that can be used for linting and formatting code when you're preparing contributions to the charm:
+
+```shell
+tox run -e format        # update your code according to linting rules
+tox run -e lint          # code style
+tox run -e static        # static type checking
+tox run -e unit          # unit tests
+tox run -e integration   # integration tests
+tox                      # runs 'format', 'lint', 'static', and 'unit' environments
+```
+
+## Build the charm
+
+Build the charm in this git repository using:
+
+```shell
+charmcraft pack
+```
+
+<!-- You may want to include any contribution/style guidelines in this document>

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023 Canonical Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This charm deploys MicroCloud on a MAAS cluster with Juju.
 ## Build the charm
 
 * Install and run `tox` to setup the virtualenv and install the python dependencies.
-* Install `charmcraft` to build the charm: `snap install charmcraft`
+* Install `charmcraft` to build the charm: `snap install charmcraft --classic`
 * Build the charm: `charmcraft pack`
 
-## Setting up a MAAS cluster to deploy our charm
+## Tutorial: setting up a MAAS cluster to deploy our charm
 
-* You can follow the instructions in `setup/maas-setup.sh`
+* You can follow the instructions in `demo/maas-setup.sh`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# MicroCloud charm for MAAS
+
+This charm deploys MicroCloud on a MAAS cluster with Juju.
+
+## Build the charm
+
+* Install and run `tox` to setup the virtualenv and install the python dependencies.
+* Install `charmcraft` to build the charm: `snap install charmcraft`
+* Build the charm: `charmcraft pack`
+
+## Setting up a MAAS cluster to deploy our charm
+
+* You can follow the instructions in `setup/maas-setup.sh`

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,16 @@
+type: charm
+bases:
+  - name: ubuntu
+    channel: "22.04"
+
+parts:
+  charm:
+    build-packages:
+      - ca-certificates
+      - cargo
+      - git
+      - libffi-dev
+      - libssl-dev
+      - pkg-config
+      - python3-dev
+      - rustc

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,29 @@
+options:
+  microovn:
+    type: boolean
+    description: Enable MicroOVN
+    default: true
+  microceph:
+    type: boolean
+    description: Enable MicroCeph
+    default: true
+  wipe:
+    type: boolean
+    description: Wipe the disks when installing
+    default: false
+  snap-channel-lxd:
+    type: string
+    default: "edge"
+    description: The snap store channel for LXD to use
+  snap-channel-microcloud:
+    type: string
+    default: "edge"
+    description: The snap store channel for MicroCloud to use
+  snap-channel-microceph:
+    type: string
+    default: "edge"
+    description: The snap store channel for MicroCeph to use
+  snap-channel-microovn:
+    type: string
+    default: "edge"
+    description: The snap store channel for MicroOVN to use

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,15 @@
+# How to setup a test MAAS cluster with Juju and a custom image server
+
+## (Optional) Local image server
+
+If you have a flaky internet connection, you can setup a local image server to locally serve the images to MAAS.
+
+```bash
+cd local-maas-image-server && ./run.sh
+```
+
+You should now have a local image server (only serving Jammy/amd64 images for the sake of this tutorial) running at `0.0.0.0:5000`. When MAAS is setup, you can go to the MAAS UI, go to `Images` and add your new image server with the following URL: `http://0.0.0.0:5000/`. No need to wait for `images.maas.io` which I found quite slow..
+
+## MAAS setup with Juju and charm deployment
+
+You can follow the instructions in `maas-setup.sh`

--- a/demo/local-maas-image-server/Dockerfile
+++ b/demo/local-maas-image-server/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:latest
+
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/demo/local-maas-image-server/nginx.conf
+++ b/demo/local-maas-image-server/nginx.conf
@@ -1,0 +1,47 @@
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # Improve performance by turning on sendfile and adjusting other parameters
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout  65;
+    client_max_body_size 5g;
+
+    # Compression reduces the response size and improves the speed
+    gzip  on;
+    gzip_min_length 10240;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml;
+    gzip_disable "MSIE [1-6]\.";
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    server {
+        listen 80;
+        server_name 0.0.0.0;
+
+        # Point to the Simplestreams data directory
+        root /usr/share/maas/images/ephemeral-v3/stable;
+
+        location / {
+            expires 30d;
+            add_header Cache-Control "public, max-age=2592000";
+            try_files $uri $uri/ =404;
+        }
+    }
+}

--- a/demo/local-maas-image-server/run.sh
+++ b/demo/local-maas-image-server/run.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+HOST_PATH="/usr/share/maas/images"
+
+if [ ! -d "$HOST_PATH" ]; then
+    echo "Warning: Directory $HOST_PATH does not exist. Creating folder..."
+    sudo mkdir -p $HOST_PATH
+fi
+
+# see here: https://maas.io/docs/mirroring-images-locally
+KEYRING_FILE=/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg
+IMAGE_SRC=https://images.maas.io/ephemeral-v3/stable
+IMAGE_DIR=/usr/share/maas/images/ephemeral-v3/stable
+
+if [ -z "$(command -v sstream-mirror)" ]; then
+    echo "sstream-mirror is not installed. Run 'sudo apt install sstream-mirror' to install it"
+    exit 1
+fi
+
+sudo sstream-mirror \
+    --keyring=$KEYRING_FILE $IMAGE_SRC $IMAGE_DIR \
+    'arch=amd64' 'release~(jammy)' --max=1 --progress
+
+sudo sstream-mirror \
+    --keyring=$KEYRING_FILE $IMAGE_SRC $IMAGE_DIR \
+    'os~(grub*|pxelinux)' --max=1 --progress
+
+docker build -t nginx-maas-image-server .
+docker run --name local-maas-image-server \
+    -d -p 5000:80 \
+    -v $HOST_PATH/ephemeral-v3/stable:/usr/share/maas/images/ephemeral-v3/stable:ro \
+    nginx-maas-image-server

--- a/demo/maas-cloud.yaml
+++ b/demo/maas-cloud.yaml
@@ -1,0 +1,5 @@
+clouds: # clouds key is required.
+  maas-cloud:
+    type: maas
+    auth-types: [oauth1]
+    endpoint: http://IP_ADDRESS:5240/MAAS

--- a/demo/maas-setup.sh
+++ b/demo/maas-setup.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root."
+    exit 1
+fi
+
+snap install --channel=latest/stable lxd
+snap refresh --channel=latest/stable lxd
+snap install maas
+snap install maas-test-db
+
+apt-get install jq -y
+
+# get local interface name (this assumes a single default route is present)
+export INTERFACE=$(ip route | grep default | awk '!/wlan|wlp|wifi/ {print $5}')
+export IP_ADDRESS=$(ip -4 addr show dev $INTERFACE | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+echo "IP_ADDRESS: $IP_ADDRESS"
+export SUBNET=10.10.10.0/24
+export LXDBR0_IPV4=10.10.10.1/24
+sed -i 's/#net.ipv4.ip_forward=1/net.ipv4.ip_forward=1/' /etc/sysctl.conf
+sysctl -p
+iptables -t nat -A POSTROUTING -o $INTERFACE -j SNAT --to $IP_ADDRESS
+
+# Persist NAT configuration
+echo iptables-persistent iptables-persistent/autosave_v4 boolean true | debconf-set-selections
+echo iptables-persistent iptables-persistent/autosave_v6 boolean true | debconf-set-selections
+apt-get install iptables-persistent -y
+
+# LXD init
+cat <<EOF | lxd init --preseed -
+config:
+  core.https_address: '[::]:8443'
+  core.trust_password: password
+networks:
+- config:
+    ipv4.address: ${LXDBR0_IPV4}
+  description: ""
+  name: lxdbr0
+  type: ""
+  project: default
+storage_pools:
+- config:
+    size: 150GB
+  description: ""
+  name: default
+  driver: zfs
+profiles:
+- config: {}
+  description: ""
+  devices:
+    eth0:
+      name: eth0
+      network: lxdbr0
+      type: nic
+    root:
+      path: /
+      pool: default
+      type: disk
+  name: default
+projects: []
+cluster: null
+EOF
+
+# verify LXD network config
+lxc network show lxdbr0
+# Wait for LXD to be ready
+lxd waitready
+# Initialise MAAS
+maas init region+rack --database-uri maas-test-db:/// --maas-url http://${IP_ADDRESS}:5240/MAAS
+# Sleeping for awhile to let MAAS do what it needs to do.
+echo "Sleeping for 30 seconds to let MAAS do what it needs to do."
+sleep 30
+
+# Create MAAS admin and grab API key
+maas createadmin --username admin --password admin --email admin
+export APIKEY=$(maas apikey --username admin)
+echo "APIKEY: $APIKEY"
+# MAAS admin login
+maas login admin 'http://localhost:5240/MAAS/' $APIKEY
+export BOOT_SOURCE_ID=$(maas boot-sources read | jq '.[0].id')
+maas admin boot-source-selections create $BOOT_SOURCE_ID os="ubuntu" release="focal" arches="amd64" subarches="*" labels="*"
+maas admin boot-source-selections create $BOOT_SOURCE_ID os="ubuntu" release="jammy" arches="amd64" subarches="*" labels="*"
+maas admin boot-resources import
+maas admin boot-resources read
+
+# Configure MAAS networking (set gateways, vlans, DHCP on etc). If you encounter errors
+# here, it might be because MAAS hasn't finished initialising. You can try waiting a bit and rerunning.
+export FABRIC_ID=$(maas admin subnet read "$SUBNET" | jq -r ".vlan.fabric_id")
+export VLAN_TAG=$(maas admin subnet read "$SUBNET" | jq -r ".vlan.vid")
+export PRIMARY_RACK=$(maas admin rack-controllers read | jq -r ".[] | .system_id")
+maas admin subnet update $SUBNET gateway_ip=10.10.10.1
+maas admin ipranges create type=dynamic start_ip=10.10.10.200 end_ip=10.10.10.254
+maas admin vlan update $FABRIC_ID $VLAN_TAG dhcp_on=True primary_rack=$PRIMARY_RACK
+maas admin maas set-config name=upstream_dns value=8.8.8.8
+# Add LXD as a VM host for MAAS and capture the VM_HOST_ID
+
+export VM_HOST_ID=$(maas admin vm-hosts create  password=password  type=lxd power_address=https://${IP_ADDRESS}:8443 project=maas | jq '.id')
+echo "VM_HOST_ID: $VM_HOST_ID"
+# allow high CPU oversubscription so all VMs can use all cores
+maas admin vm-host update $VM_HOST_ID cpu_over_commit_ratio=4
+
+# create tags for MAAS
+maas admin tags create name=juju-controller comment='This tag should to machines that will be used as juju controllers'
+maas admin tags create name=metal comment='This tag should to machines that will be used as bare metal'
+
+### creating VMs for Juju controller and our "bare metal"
+
+# add a VM for the juju controller with minimal memory
+maas admin vm-host compose $VM_HOST_ID cores=4 memory=4096 architecture="amd64/generic" storage="main:16(pool1)" hostname="juju-controller"
+# get the system-id and tag the machine with "juju-controller"
+export JUJU_SYSID=$(maas admin machines read | jq  '.[] | select(."hostname"=="juju-controller") | .["system_id"]' | tr -d '"')
+maas admin tag update-nodes "juju-controller" add=$JUJU_SYSID
+
+## Create 3 "bare metal" machines and tag them with "metal"
+for ID in 1 2 3
+do
+    maas admin vm-host compose $VM_HOST_ID cores=4 memory=4096 architecture="amd64/generic" storage="main:10(pool1),ceph:20(pool1)" hostname="metal-${ID}"
+	  SYSID=$(maas admin machines read | jq -r --arg MACHINE "metal-${ID}" '.[] | select(."hostname"==$MACHINE) | .["system_id"]' | tr -d '"')
+    maas admin tag update-nodes "metal" add=$SYSID
+done
+
+### Juju setup (note, this section requires manual intervention and you need to wait for all the maas machines to be commissioned and ready)
+
+# snap install juju
+# rm -r ~/.local/share/juju/
+# sed -i "s/IP_ADDRESS/$IP_ADDRESS/" maas-cloud.yaml
+# juju add-cloud maas-cloud maas-cloud.yaml
+# juju add-credential maas-cloud
+# juju clouds
+# juju credentials
+
+# # Go on the MAAS UI at $IP_ADDRESS:5240/MAAS, login (username: admin, password: admin), and add Ubuntu 22.04/amd64 in the available images.
+# # Wait for MAAS to download the image and continue. This step is required for the following `juju bootstrap` command to complete.
+
+# # Bootstrap the maas-cloud - get a coffee
+# juju bootstrap maas-cloud --bootstrap-constraints "tags=juju-controller mem=2G"
+
+# juju add-model microcloud maas-cloud
+
+# # check jujus view of machines
+# juju machines
+
+# # add machines to juju from the maas cloud
+# # it will grab the 3 we already created since they are in a "READY state"
+# juju add-machine -n 3
+
+# # take a look at machines list again, you should see 3 machines. Wait for all of them to be in a "started" state. It could take a while...
+# juju machines
+
+# # Create a model in juju
+# juju add-model microcloud
+
+# # Pack the charm and deploy it to our 3 machines
+# cd ../ && charmcraft pack && juju deploy ./microcloud_ubuntu-22.04-amd64.charm -n 3 --to 0,1,2
+
+# # You can add more machines to the model and scale up the application
+
+# # Let's add the 'metal-4' machine on MAAS and add it to the juju model
+# maas admin vm-host compose $VM_HOST_ID cores=4 memory=4096 architecture="amd64/generic" storage="main:10(pool1),ceph:20(pool1)" hostname="metal-4"
+# SYSID=$(maas admin machines read | jq -r --arg MACHINE "metal-4" '.[] | select(."hostname"==$MACHINE) | .["system_id"]' | tr -d '"')
+# maas admin tag update-nodes "metal" add=$SYSID
+
+# # Add the machine to juju once the machine is in a "ready" state
+# juju add-machine
+# juju machines
+
+# # Scale up the application to the new machine (the new machine should have the identifier '3' on JuJu)
+# juju add-unit microcloud -n 1 --to 3
+
+# # Scale down the application
+# juju remove-unit microcloud/3

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -1,0 +1,1099 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Representations of the system's Snaps, and abstractions around managing them.
+
+The `snap` module provides convenience methods for listing, installing, refreshing, and removing
+Snap packages, in addition to setting and getting configuration options for them.
+
+In the `snap` module, `SnapCache` creates a dict-like mapping of `Snap` objects at when
+instantiated. Installed snaps are fully populated, and available snaps are lazily-loaded upon
+request. This module relies on an installed and running `snapd` daemon to perform operations over
+the `snapd` HTTP API.
+
+`SnapCache` objects can be used to install or modify Snap packages by name in a manner similar to
+using the `snap` command from the commandline.
+
+An example of adding Juju to the system with `SnapCache` and setting a config value:
+
+```python
+try:
+    cache = snap.SnapCache()
+    juju = cache["juju"]
+
+    if not juju.present:
+        juju.ensure(snap.SnapState.Latest, channel="beta")
+        juju.set({"some.key": "value", "some.key2": "value2"})
+except snap.SnapError as e:
+    logger.error("An exception occurred when installing charmcraft. Reason: %s", e.message)
+```
+
+In addition, the `snap` module provides "bare" methods which can act on Snap packages as
+simple function calls. :meth:`add`, :meth:`remove`, and :meth:`ensure` are provided, as
+well as :meth:`add_local` for installing directly from a local `.snap` file. These return
+`Snap` objects.
+
+As an example of installing several Snaps and checking details:
+
+```python
+try:
+    nextcloud, charmcraft = snap.add(["nextcloud", "charmcraft"])
+    if nextcloud.get("mode") != "production":
+        nextcloud.set({"mode": "production"})
+except snap.SnapError as e:
+    logger.error("An exception occurred when installing snaps. Reason: %s" % e.message)
+```
+"""
+
+import http.client
+import json
+import logging
+import os
+import re
+import socket
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from subprocess import CalledProcessError, CompletedProcess
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "05394e5893f94f2d90feb7cbe6b633cd"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 2
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+
+# Regex to locate 7-bit C1 ANSI sequences
+ansi_filter = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def _cache_init(func):
+    def inner(*args, **kwargs):
+        if _Cache.cache is None:
+            _Cache.cache = SnapCache()
+        return func(*args, **kwargs)
+
+    return inner
+
+
+# recursive hints seems to error out pytest
+JSONType = Union[Dict[str, Any], List[Any], str, int, float]
+
+
+class SnapService:
+    """Data wrapper for snap services."""
+
+    def __init__(
+        self,
+        daemon: Optional[str] = None,
+        daemon_scope: Optional[str] = None,
+        enabled: bool = False,
+        active: bool = False,
+        activators: List[str] = [],
+        **kwargs,
+    ):
+        self.daemon = daemon
+        self.daemon_scope = kwargs.get("daemon-scope", None) or daemon_scope
+        self.enabled = enabled
+        self.active = active
+        self.activators = activators
+
+    def as_dict(self) -> Dict:
+        """Return instance representation as dict."""
+        return {
+            "daemon": self.daemon,
+            "daemon_scope": self.daemon_scope,
+            "enabled": self.enabled,
+            "active": self.active,
+            "activators": self.activators,
+        }
+
+
+class MetaCache(type):
+    """MetaCache class used for initialising the snap cache."""
+
+    @property
+    def cache(cls) -> "SnapCache":
+        """Property for returning the snap cache."""
+        return cls._cache
+
+    @cache.setter
+    def cache(cls, cache: "SnapCache") -> None:
+        """Setter for the snap cache."""
+        cls._cache = cache
+
+    def __getitem__(cls, name) -> "Snap":
+        """Snap cache getter."""
+        return cls._cache[name]
+
+
+class _Cache(object, metaclass=MetaCache):
+    _cache = None
+
+
+class Error(Exception):
+    """Base class of most errors raised by this library."""
+
+    def __repr__(self):
+        """Represent the Error class."""
+        return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
+
+    @property
+    def name(self):
+        """Return a string representation of the model plus class."""
+        return "<{}.{}>".format(type(self).__module__, type(self).__name__)
+
+    @property
+    def message(self):
+        """Return the message passed as an argument."""
+        return self.args[0]
+
+
+class SnapAPIError(Error):
+    """Raised when an HTTP API error occurs talking to the Snapd server."""
+
+    def __init__(self, body: Dict, code: int, status: str, message: str):
+        super().__init__(message)  # Makes str(e) return message
+        self.body = body
+        self.code = code
+        self.status = status
+        self._message = message
+
+    def __repr__(self):
+        """Represent the SnapAPIError class."""
+        return "APIError({!r}, {!r}, {!r}, {!r})".format(
+            self.body, self.code, self.status, self._message
+        )
+
+
+class SnapState(Enum):
+    """The state of a snap on the system or in the cache."""
+
+    Present = "present"
+    Absent = "absent"
+    Latest = "latest"
+    Available = "available"
+
+
+class SnapError(Error):
+    """Raised when there's an error running snap control commands."""
+
+
+class SnapNotFoundError(Error):
+    """Raised when a requested snap is not known to the system."""
+
+
+class Snap(object):
+    """Represents a snap package and its properties.
+
+    `Snap` exposes the following properties about a snap:
+      - name: the name of the snap
+      - state: a `SnapState` representation of its install status
+      - channel: "stable", "candidate", "beta", and "edge" are common
+      - revision: a string representing the snap's revision
+      - confinement: "classic" or "strict"
+    """
+
+    def __init__(
+        self,
+        name,
+        state: SnapState,
+        channel: str,
+        revision: str,
+        confinement: str,
+        apps: Optional[List[Dict[str, str]]] = None,
+        cohort: Optional[str] = "",
+    ) -> None:
+        self._name = name
+        self._state = state
+        self._channel = channel
+        self._revision = revision
+        self._confinement = confinement
+        self._cohort = cohort
+        self._apps = apps or []
+        self._snap_client = SnapClient()
+
+    def __eq__(self, other) -> bool:
+        """Equality for comparison."""
+        return isinstance(other, self.__class__) and (
+            self._name,
+            self._revision,
+        ) == (other._name, other._revision)
+
+    def __hash__(self):
+        """Calculate a hash for this snap."""
+        return hash((self._name, self._revision))
+
+    def __repr__(self):
+        """Represent the object such that it can be reconstructed."""
+        return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
+
+    def __str__(self):
+        """Represent the snap object as a string."""
+        return "<{}: {}-{}.{} -- {}>".format(
+            self.__class__.__name__,
+            self._name,
+            self._revision,
+            self._channel,
+            str(self._state),
+        )
+
+    def _snap(self, command: str, optargs: Optional[Iterable[str]] = None) -> str:
+        """Perform a snap operation.
+
+        Args:
+          command: the snap command to execute
+          optargs: an (optional) list of additional arguments to pass,
+            commonly confinement or channel
+
+        Raises:
+          SnapError if there is a problem encountered
+        """
+        optargs = optargs or []
+        args = ["snap", command, self._name, *optargs]
+        try:
+            return subprocess.check_output(args, universal_newlines=True)
+        except CalledProcessError as e:
+            raise SnapError(
+                "Snap: {!r}; command {!r} failed with output = {!r}".format(
+                    self._name, args, e.output
+                )
+            )
+
+    def _snap_daemons(
+        self,
+        command: List[str],
+        services: Optional[List[str]] = None,
+    ) -> CompletedProcess:
+        """Perform snap app commands.
+
+        Args:
+          command: the snap command to execute
+          services: the snap service to execute command on
+
+        Raises:
+          SnapError if there is a problem encountered
+        """
+        if services:
+            # an attempt to keep the command constrained to the snap instance's services
+            services = ["{}.{}".format(self._name, service) for service in services]
+        else:
+            services = [self._name]
+
+        args = ["snap", *command, *services]
+
+        try:
+            return subprocess.run(args, universal_newlines=True, check=True, capture_output=True)
+        except CalledProcessError as e:
+            raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
+
+    def get(self, key: Optional[str], *, typed: bool = False) -> Any:
+        """Fetch snap configuration values.
+
+        Args:
+            key: the key to retrieve. Default to retrieve all values for typed=True.
+            typed: set to True to retrieve typed values (set with typed=True).
+                Default is to return a string.
+        """
+        if typed:
+            config = json.loads(self._snap("get", ["-d", key]))
+            if key:
+                return config.get(key)
+            return config
+
+        if not key:
+            raise TypeError("Key must be provided when typed=False")
+
+        return self._snap("get", [key]).strip()
+
+    def set(self, config: Dict[str, Any], *, typed: bool = False) -> str:
+        """Set a snap configuration value.
+
+        Args:
+           config: a dictionary containing keys and values specifying the config to set.
+           typed: set to True to convert all values in the config into typed values while
+                configuring the snap (set with typed=True). Default is not to convert.
+        """
+        if typed:
+            kv = [f"{key}={json.dumps(val)}" for key, val in config.items()]
+            return self._snap("set", ["-t"] + kv)
+
+        return self._snap("set", [f"{key}={val}" for key, val in config.items()])
+
+    def unset(self, key) -> str:
+        """Unset a snap configuration value.
+
+        Args:
+            key: the key to unset
+        """
+        return self._snap("unset", [key])
+
+    def start(self, services: Optional[List[str]] = None, enable: Optional[bool] = False) -> None:
+        """Start a snap's services.
+
+        Args:
+            services (list): (optional) list of individual snap services to start (otherwise all)
+            enable (bool): (optional) flag to enable snap services on start. Default `false`
+        """
+        args = ["start", "--enable"] if enable else ["start"]
+        self._snap_daemons(args, services)
+
+    def stop(self, services: Optional[List[str]] = None, disable: Optional[bool] = False) -> None:
+        """Stop a snap's services.
+
+        Args:
+            services (list): (optional) list of individual snap services to stop (otherwise all)
+            disable (bool): (optional) flag to disable snap services on stop. Default `False`
+        """
+        args = ["stop", "--disable"] if disable else ["stop"]
+        self._snap_daemons(args, services)
+
+    def logs(self, services: Optional[List[str]] = None, num_lines: Optional[int] = 10) -> str:
+        """Fetch a snap services' logs.
+
+        Args:
+            services (list): (optional) list of individual snap services to show logs from
+                (otherwise all)
+            num_lines (int): (optional) integer number of log lines to return. Default `10`
+        """
+        args = ["logs", "-n={}".format(num_lines)] if num_lines else ["logs"]
+        return self._snap_daemons(args, services).stdout
+
+    def connect(
+        self, plug: str, service: Optional[str] = None, slot: Optional[str] = None
+    ) -> None:
+        """Connect a plug to a slot.
+
+        Args:
+            plug (str): the plug to connect
+            service (str): (optional) the snap service name to plug into
+            slot (str): (optional) the snap service slot to plug in to
+
+        Raises:
+            SnapError if there is a problem encountered
+        """
+        command = ["connect", "{}:{}".format(self._name, plug)]
+
+        if service and slot:
+            command = command + ["{}:{}".format(service, slot)]
+        elif slot:
+            command = command + [slot]
+
+        args = ["snap", *command]
+        try:
+            subprocess.run(args, universal_newlines=True, check=True, capture_output=True)
+        except CalledProcessError as e:
+            raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
+
+    def hold(self, duration: Optional[timedelta] = None) -> None:
+        """Add a refresh hold to a snap.
+
+        Args:
+            duration: duration for the hold, or None (the default) to hold this snap indefinitely.
+        """
+        hold_str = "forever"
+        if duration is not None:
+            seconds = round(duration.total_seconds())
+            hold_str = f"{seconds}s"
+        self._snap("refresh", [f"--hold={hold_str}"])
+
+    def unhold(self) -> None:
+        """Remove the refresh hold of a snap."""
+        self._snap("refresh", ["--unhold"])
+
+    def alias(self, application: str, alias: Optional[str] = None) -> None:
+        """Create an alias for a given application.
+
+        Args:
+            application: application to get an alias.
+            alias: (optional) name of the alias; if not provided, the application name is used.
+        """
+        if alias is None:
+            alias = application
+        args = ["snap", "alias", f"{self.name}.{application}", alias]
+        try:
+            subprocess.check_output(args, universal_newlines=True)
+        except CalledProcessError as e:
+            raise SnapError(
+                "Snap: {!r}; command {!r} failed with output = {!r}".format(
+                    self._name, args, e.output
+                )
+            )
+
+    def restart(
+        self, services: Optional[List[str]] = None, reload: Optional[bool] = False
+    ) -> None:
+        """Restarts a snap's services.
+
+        Args:
+            services (list): (optional) list of individual snap services to restart.
+                (otherwise all)
+            reload (bool): (optional) flag to use the service reload command, if available.
+                Default `False`
+        """
+        args = ["restart", "--reload"] if reload else ["restart"]
+        self._snap_daemons(args, services)
+
+    def _install(
+        self,
+        channel: Optional[str] = "",
+        cohort: Optional[str] = "",
+        revision: Optional[str] = None,
+    ) -> None:
+        """Add a snap to the system.
+
+        Args:
+          channel: the channel to install from
+          cohort: optional, the key of a cohort that this snap belongs to
+          revision: optional, the revision of the snap to install
+        """
+        cohort = cohort or self._cohort
+
+        args = []
+        if self.confinement == "classic":
+            args.append("--classic")
+        if channel:
+            args.append('--channel="{}"'.format(channel))
+        if revision:
+            args.append('--revision="{}"'.format(revision))
+        if cohort:
+            args.append('--cohort="{}"'.format(cohort))
+
+        self._snap("install", args)
+
+    def _refresh(
+        self,
+        channel: Optional[str] = "",
+        cohort: Optional[str] = "",
+        revision: Optional[str] = None,
+        leave_cohort: Optional[bool] = False,
+    ) -> None:
+        """Refresh a snap.
+
+        Args:
+          channel: the channel to install from
+          cohort: optionally, specify a cohort.
+          revision: optionally, specify the revision of the snap to refresh
+          leave_cohort: leave the current cohort.
+        """
+        args = []
+        if channel:
+            args.append('--channel="{}"'.format(channel))
+
+        if revision:
+            args.append('--revision="{}"'.format(revision))
+
+        if not cohort:
+            cohort = self._cohort
+
+        if leave_cohort:
+            self._cohort = ""
+            args.append("--leave-cohort")
+        elif cohort:
+            args.append('--cohort="{}"'.format(cohort))
+
+        self._snap("refresh", args)
+
+    def _remove(self) -> str:
+        """Remove a snap from the system."""
+        return self._snap("remove")
+
+    @property
+    def name(self) -> str:
+        """Returns the name of the snap."""
+        return self._name
+
+    def ensure(
+        self,
+        state: SnapState,
+        classic: Optional[bool] = False,
+        channel: Optional[str] = "",
+        cohort: Optional[str] = "",
+        revision: Optional[str] = None,
+    ):
+        """Ensure that a snap is in a given state.
+
+        Args:
+          state: a `SnapState` to reconcile to.
+          classic: an (Optional) boolean indicating whether classic confinement should be used
+          channel: the channel to install from
+          cohort: optional. Specify the key of a snap cohort.
+          revision: optional. the revision of the snap to install/refresh
+
+        While both channel and revision could be specified, the underlying snap install/refresh
+        command will determine which one takes precedence (revision at this time)
+
+        Raises:
+          SnapError if an error is encountered
+        """
+        self._confinement = "classic" if classic or self._confinement == "classic" else ""
+
+        if state not in (SnapState.Present, SnapState.Latest):
+            # We are attempting to remove this snap.
+            if self._state in (SnapState.Present, SnapState.Latest):
+                # The snap is installed, so we run _remove.
+                self._remove()
+            else:
+                # The snap is not installed -- no need to do anything.
+                pass
+        else:
+            # We are installing or refreshing a snap.
+            if self._state not in (SnapState.Present, SnapState.Latest):
+                # The snap is not installed, so we install it.
+                self._install(channel, cohort, revision)
+            else:
+                # The snap is installed, but we are changing it (e.g., switching channels).
+                self._refresh(channel, cohort, revision)
+
+        self._update_snap_apps()
+        self._state = state
+
+    def _update_snap_apps(self) -> None:
+        """Update a snap's apps after snap changes state."""
+        try:
+            self._apps = self._snap_client.get_installed_snap_apps(self._name)
+        except SnapAPIError:
+            logger.debug("Unable to retrieve snap apps for {}".format(self._name))
+            self._apps = []
+
+    @property
+    def present(self) -> bool:
+        """Report whether or not a snap is present."""
+        return self._state in (SnapState.Present, SnapState.Latest)
+
+    @property
+    def latest(self) -> bool:
+        """Report whether the snap is the most recent version."""
+        return self._state is SnapState.Latest
+
+    @property
+    def state(self) -> SnapState:
+        """Report the current snap state."""
+        return self._state
+
+    @state.setter
+    def state(self, state: SnapState) -> None:
+        """Set the snap state to a given value.
+
+        Args:
+          state: a `SnapState` to reconcile the snap to.
+
+        Raises:
+          SnapError if an error is encountered
+        """
+        if self._state is not state:
+            self.ensure(state)
+        self._state = state
+
+    @property
+    def revision(self) -> str:
+        """Returns the revision for a snap."""
+        return self._revision
+
+    @property
+    def channel(self) -> str:
+        """Returns the channel for a snap."""
+        return self._channel
+
+    @property
+    def confinement(self) -> str:
+        """Returns the confinement for a snap."""
+        return self._confinement
+
+    @property
+    def apps(self) -> List:
+        """Returns (if any) the installed apps of the snap."""
+        self._update_snap_apps()
+        return self._apps
+
+    @property
+    def services(self) -> Dict:
+        """Returns (if any) the installed services of the snap."""
+        self._update_snap_apps()
+        services = {}
+        for app in self._apps:
+            if "daemon" in app:
+                services[app["name"]] = SnapService(**app).as_dict()
+
+        return services
+
+    @property
+    def held(self) -> bool:
+        """Report whether the snap has a hold."""
+        info = self._snap("info")
+        return "hold:" in info
+
+
+class _UnixSocketConnection(http.client.HTTPConnection):
+    """Implementation of HTTPConnection that connects to a named Unix socket."""
+
+    def __init__(self, host, timeout=None, socket_path=None):
+        if timeout is None:
+            super().__init__(host)
+        else:
+            super().__init__(host, timeout=timeout)
+        self.socket_path = socket_path
+
+    def connect(self):
+        """Override connect to use Unix socket (instead of TCP socket)."""
+        if not hasattr(socket, "AF_UNIX"):
+            raise NotImplementedError("Unix sockets not supported on {}".format(sys.platform))
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.socket_path)
+        if self.timeout is not None:
+            self.sock.settimeout(self.timeout)
+
+
+class _UnixSocketHandler(urllib.request.AbstractHTTPHandler):
+    """Implementation of HTTPHandler that uses a named Unix socket."""
+
+    def __init__(self, socket_path: str):
+        super().__init__()
+        self.socket_path = socket_path
+
+    def http_open(self, req) -> http.client.HTTPResponse:
+        """Override http_open to use a Unix socket connection (instead of TCP)."""
+        return self.do_open(_UnixSocketConnection, req, socket_path=self.socket_path)
+
+
+class SnapClient:
+    """Snapd API client to talk to HTTP over UNIX sockets.
+
+    In order to avoid shelling out and/or involving sudo in calling the snapd API,
+    use a wrapper based on the Pebble Client, trimmed down to only the utility methods
+    needed for talking to snapd.
+    """
+
+    def __init__(
+        self,
+        socket_path: str = "/run/snapd.socket",
+        opener: Optional[urllib.request.OpenerDirector] = None,
+        base_url: str = "http://localhost/v2/",
+        timeout: float = 30.0,
+    ):
+        """Initialize a client instance.
+
+        Args:
+            socket_path: a path to the socket on the filesystem. Defaults to /run/snap/snapd.socket
+            opener: specifies an opener for unix socket, if unspecified a default is used
+            base_url: base url for making requests to the snap client. Defaults to
+                http://localhost/v2/
+            timeout: timeout in seconds to use when making requests to the API. Default is 30.0s.
+        """
+        if opener is None:
+            opener = self._get_default_opener(socket_path)
+        self.opener = opener
+        self.base_url = base_url
+        self.timeout = timeout
+
+    @classmethod
+    def _get_default_opener(cls, socket_path):
+        """Build the default opener to use for requests (HTTP over Unix socket)."""
+        opener = urllib.request.OpenerDirector()
+        opener.add_handler(_UnixSocketHandler(socket_path))
+        opener.add_handler(urllib.request.HTTPDefaultErrorHandler())
+        opener.add_handler(urllib.request.HTTPRedirectHandler())
+        opener.add_handler(urllib.request.HTTPErrorProcessor())
+        return opener
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        query: Dict = None,
+        body: Dict = None,
+    ) -> JSONType:
+        """Make a JSON request to the Snapd server with the given HTTP method and path.
+
+        If query dict is provided, it is encoded and appended as a query string
+        to the URL. If body dict is provided, it is serialied as JSON and used
+        as the HTTP body (with Content-Type: "application/json"). The resulting
+        body is decoded from JSON.
+        """
+        headers = {"Accept": "application/json"}
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        response = self._request_raw(method, path, query, headers, data)
+        return json.loads(response.read().decode())["result"]
+
+    def _request_raw(
+        self,
+        method: str,
+        path: str,
+        query: Dict = None,
+        headers: Dict = None,
+        data: bytes = None,
+    ) -> http.client.HTTPResponse:
+        """Make a request to the Snapd server; return the raw HTTPResponse object."""
+        url = self.base_url + path
+        if query:
+            url = url + "?" + urllib.parse.urlencode(query)
+
+        if headers is None:
+            headers = {}
+        request = urllib.request.Request(url, method=method, data=data, headers=headers)
+
+        try:
+            response = self.opener.open(request, timeout=self.timeout)
+        except urllib.error.HTTPError as e:
+            code = e.code
+            status = e.reason
+            message = ""
+            try:
+                body = json.loads(e.read().decode())["result"]
+            except (IOError, ValueError, KeyError) as e2:
+                # Will only happen on read error or if Pebble sends invalid JSON.
+                body = {}
+                message = "{} - {}".format(type(e2).__name__, e2)
+            raise SnapAPIError(body, code, status, message)
+        except urllib.error.URLError as e:
+            raise SnapAPIError({}, 500, "Not found", e.reason)
+        return response
+
+    def get_installed_snaps(self) -> Dict:
+        """Get information about currently installed snaps."""
+        return self._request("GET", "snaps")
+
+    def get_snap_information(self, name: str) -> Dict:
+        """Query the snap server for information about single snap."""
+        return self._request("GET", "find", {"name": name})[0]
+
+    def get_installed_snap_apps(self, name: str) -> List:
+        """Query the snap server for apps belonging to a named, currently installed snap."""
+        return self._request("GET", "apps", {"names": name, "select": "service"})
+
+
+class SnapCache(Mapping):
+    """An abstraction to represent installed/available packages.
+
+    When instantiated, `SnapCache` iterates through the list of installed
+    snaps using the `snapd` HTTP API, and a list of available snaps by reading
+    the filesystem to populate the cache. Information about available snaps is lazily-loaded
+    from the `snapd` API when requested.
+    """
+
+    def __init__(self):
+        if not self.snapd_installed:
+            raise SnapError("snapd is not installed or not in /usr/bin") from None
+        self._snap_client = SnapClient()
+        self._snap_map = {}
+        if self.snapd_installed:
+            self._load_available_snaps()
+            self._load_installed_snaps()
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a given snap is in the cache."""
+        return key in self._snap_map
+
+    def __len__(self) -> int:
+        """Report number of items in the snap cache."""
+        return len(self._snap_map)
+
+    def __iter__(self) -> Iterable["Snap"]:
+        """Provide iterator for the snap cache."""
+        return iter(self._snap_map.values())
+
+    def __getitem__(self, snap_name: str) -> Snap:
+        """Return either the installed version or latest version for a given snap."""
+        snap = self._snap_map.get(snap_name, None)
+        if snap is None:
+            # The snapd cache file may not have existed when _snap_map was
+            # populated.  This is normal.
+            try:
+                self._snap_map[snap_name] = self._load_info(snap_name)
+            except SnapAPIError:
+                raise SnapNotFoundError("Snap '{}' not found!".format(snap_name))
+
+        return self._snap_map[snap_name]
+
+    @property
+    def snapd_installed(self) -> bool:
+        """Check whether snapd has been installled on the system."""
+        return os.path.isfile("/usr/bin/snap")
+
+    def _load_available_snaps(self) -> None:
+        """Load the list of available snaps from disk.
+
+        Leave them empty and lazily load later if asked for.
+        """
+        if not os.path.isfile("/var/cache/snapd/names"):
+            # The snap catalog may not be populated yet; this is normal.
+            # snapd updates the cache infrequently and the cache file may not
+            # currently exist.
+            return
+
+        with open("/var/cache/snapd/names", "r") as f:
+            for line in f:
+                if line.strip():
+                    self._snap_map[line.strip()] = None
+
+    def _load_installed_snaps(self) -> None:
+        """Load the installed snaps into the dict."""
+        installed = self._snap_client.get_installed_snaps()
+
+        for i in installed:
+            snap = Snap(
+                name=i["name"],
+                state=SnapState.Latest,
+                channel=i["channel"],
+                revision=i["revision"],
+                confinement=i["confinement"],
+                apps=i.get("apps", None),
+            )
+            self._snap_map[snap.name] = snap
+
+    def _load_info(self, name) -> Snap:
+        """Load info for snaps which are not installed if requested.
+
+        Args:
+            name: a string representing the name of the snap
+        """
+        info = self._snap_client.get_snap_information(name)
+
+        return Snap(
+            name=info["name"],
+            state=SnapState.Available,
+            channel=info["channel"],
+            revision=info["revision"],
+            confinement=info["confinement"],
+            apps=None,
+        )
+
+
+@_cache_init
+def add(
+    snap_names: Union[str, List[str]],
+    state: Union[str, SnapState] = SnapState.Latest,
+    channel: Optional[str] = "",
+    classic: Optional[bool] = False,
+    cohort: Optional[str] = "",
+    revision: Optional[str] = None,
+) -> Union[Snap, List[Snap]]:
+    """Add a snap to the system.
+
+    Args:
+        snap_names: the name or names of the snaps to install
+        state: a string or `SnapState` representation of the desired state, one of
+            [`Present` or `Latest`]
+        channel: an (Optional) channel as a string. Defaults to 'latest'
+        classic: an (Optional) boolean specifying whether it should be added with classic
+            confinement. Default `False`
+        cohort: an (Optional) string specifying the snap cohort to use
+        revision: an (Optional) string specifying the snap revision to use
+
+    Raises:
+        SnapError if some snaps failed to install or were not found.
+    """
+    if not channel and not revision:
+        channel = "latest"
+
+    snap_names = [snap_names] if isinstance(snap_names, str) else snap_names
+    if not snap_names:
+        raise TypeError("Expected at least one snap to add, received zero!")
+
+    if isinstance(state, str):
+        state = SnapState(state)
+
+    return _wrap_snap_operations(snap_names, state, channel, classic, cohort, revision)
+
+
+@_cache_init
+def remove(snap_names: Union[str, List[str]]) -> Union[Snap, List[Snap]]:
+    """Remove specified snap(s) from the system.
+
+    Args:
+        snap_names: the name or names of the snaps to install
+
+    Raises:
+        SnapError if some snaps failed to install.
+    """
+    snap_names = [snap_names] if isinstance(snap_names, str) else snap_names
+    if not snap_names:
+        raise TypeError("Expected at least one snap to add, received zero!")
+
+    return _wrap_snap_operations(snap_names, SnapState.Absent, "", False)
+
+
+@_cache_init
+def ensure(
+    snap_names: Union[str, List[str]],
+    state: str,
+    channel: Optional[str] = "",
+    classic: Optional[bool] = False,
+    cohort: Optional[str] = "",
+    revision: Optional[int] = None,
+) -> Union[Snap, List[Snap]]:
+    """Ensure specified snaps are in a given state on the system.
+
+    Args:
+        snap_names: the name(s) of the snaps to operate on
+        state: a string representation of the desired state, from `SnapState`
+        channel: an (Optional) channel as a string. Defaults to 'latest'
+        classic: an (Optional) boolean specifying whether it should be added with classic
+            confinement. Default `False`
+        cohort: an (Optional) string specifying the snap cohort to use
+        revision: an (Optional) integer specifying the snap revision to use
+
+    When both channel and revision are specified, the underlying snap install/refresh
+    command will determine the precedence (revision at the time of adding this)
+
+    Raises:
+        SnapError if the snap is not in the cache.
+    """
+    if not revision and not channel:
+        channel = "latest"
+
+    if state in ("present", "latest") or revision:
+        return add(snap_names, SnapState(state), channel, classic, cohort, revision)
+    else:
+        return remove(snap_names)
+
+
+def _wrap_snap_operations(
+    snap_names: List[str],
+    state: SnapState,
+    channel: str,
+    classic: bool,
+    cohort: Optional[str] = "",
+    revision: Optional[str] = None,
+) -> Union[Snap, List[Snap]]:
+    """Wrap common operations for bare commands."""
+    snaps = {"success": [], "failed": []}
+
+    op = "remove" if state is SnapState.Absent else "install or refresh"
+
+    for s in snap_names:
+        try:
+            snap = _Cache[s]
+            if state is SnapState.Absent:
+                snap.ensure(state=SnapState.Absent)
+            else:
+                snap.ensure(
+                    state=state, classic=classic, channel=channel, cohort=cohort, revision=revision
+                )
+            snaps["success"].append(snap)
+        except SnapError as e:
+            logger.warning("Failed to {} snap {}: {}!".format(op, s, e.message))
+            snaps["failed"].append(s)
+        except SnapNotFoundError:
+            logger.warning("Snap '{}' not found in cache!".format(s))
+            snaps["failed"].append(s)
+
+    if len(snaps["failed"]):
+        raise SnapError(
+            "Failed to install or refresh snap(s): {}".format(", ".join(list(snaps["failed"])))
+        )
+
+    return snaps["success"] if len(snaps["success"]) > 1 else snaps["success"][0]
+
+
+def install_local(
+    filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
+) -> Snap:
+    """Perform a snap operation.
+
+    Args:
+        filename: the path to a local .snap file to install
+        classic: whether to use classic confinement
+        dangerous: whether --dangerous should be passed to install snaps without a signature
+
+    Raises:
+        SnapError if there is a problem encountered
+    """
+    args = [
+        "snap",
+        "install",
+        filename,
+    ]
+    if classic:
+        args.append("--classic")
+    if dangerous:
+        args.append("--dangerous")
+    try:
+        result = subprocess.check_output(args, universal_newlines=True).splitlines()[-1]
+        snap_name, _ = result.split(" ", 1)
+        snap_name = ansi_filter.sub("", snap_name)
+
+        c = SnapCache()
+
+        try:
+            return c[snap_name]
+        except SnapAPIError as e:
+            logger.error(
+                "Could not find snap {} when querying Snapd socket: {}".format(snap_name, e.body)
+            )
+            raise SnapError("Failed to find snap {} in Snap cache".format(snap_name))
+    except CalledProcessError as e:
+        raise SnapError("Could not install snap {}: {}".format(filename, e.output))
+
+
+def _system_set(config_item: str, value: str) -> None:
+    """Set system snapd config values.
+
+    Args:
+        config_item: name of snap system setting. E.g. 'refresh.hold'
+        value: value to assign
+    """
+    args = ["snap", "set", "system", "{}={}".format(config_item, value)]
+    try:
+        subprocess.check_call(args, universal_newlines=True)
+    except CalledProcessError:
+        raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
+
+
+def hold_refresh(days: int = 90, forever: bool = False) -> bool:
+    """Set the system-wide snap refresh hold.
+
+    Args:
+        days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
+        forever: if True, will set a hold forever.
+    """
+    if not isinstance(forever, bool):
+        raise TypeError("forever must be a bool")
+    if not isinstance(days, int):
+        raise TypeError("days must be an int")
+    if forever:
+        _system_set("refresh.hold", "forever")
+        logger.info("Set system-wide snap refresh hold to: forever")
+    elif days == 0:
+        _system_set("refresh.hold", "")
+        logger.info("Removed system-wide snap refresh hold")
+    else:
+        # Currently the snap daemon can only hold for a maximum of 90 days
+        if not 1 <= days <= 90:
+            raise ValueError("days must be between 1 and 90")
+        # Add the number of days to current time
+        target_date = datetime.now(timezone.utc).astimezone() + timedelta(days=days)
+        # Format for the correct datetime format
+        hold_date = target_date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        # Python dumps the offset in format '+0100', we need '+01:00'
+        hold_date = "{0}:{1}".format(hold_date[:-2], hold_date[-2:])
+        # Actually set the hold date
+        _system_set("refresh.hold", hold_date)
+        logger.info("Set system-wide snap refresh hold to: %s", hold_date)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,44 @@
+name: microcloud
+display-name: MicroCloud
+summary: The easiest way to get a fully highly available LXD cluster up and running.
+description: |
+  MicroCloud can automatically configure LXD, Ceph, and OVN across a set of servers.
+  It relies on mDNS to automatically detect other servers on the network, making it possible
+  to set up a complete cluster by running a single command on one of the machines.
+
+  MicroCloud creates a small footprint cluster of compute nodes with distributed
+  storage and secure networking, optimized for repeatable, reliable remote deployments.
+  MicroCloud is aimed at edge computing, and anyone in need of a small-scale private cloud.
+tags:
+  - containers
+  - security
+  - system
+resources:
+  microcloud-binary:
+    type: file
+    filename: microcloud
+    description: |
+      A debug version of the MicroCloud binary or a tarball of architecture specific
+      binaries. In the case of a tarball, the binaries should be at the root
+      and be named as "microcloud_${ARCH}".
+
+      Attaching an empty file will undo the sideloading.
+  microcloud-snap:
+    type: file
+    filename: microcloud.snap
+    description: |
+      A custom MicroCloud snap or tarball of architecture specific snaps to install.
+      In the case of a tarball, the snaps should be at the root and be
+      named as "microcloud_${ARCH}.snap".
+
+      Attaching an empty file will undo the sideloading.
+storage:
+  local:
+    type: block
+    description: Local storage pool for MicroCeph
+    minimum-size: 10G
+    multiple:
+      range: 0-1
+peers:
+  cluster:
+    interface: microcloud-cluster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,59 @@
+[project]
+name = "charm-microcloud-machine"
+description = "Machine Charm for MicroCloud"
+license = "Apache 2.0"
+python = "^3.10"
+readme = "README.md"
+repository = "https://github.com/canonical/microcloud"
+
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+# Formatting tools configuration
+[tool.black]
+line-length = 99
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+
+# Linting tools configuration
+[tool.flake8]
+max-line-length = 99
+max-doc-length = 99
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+select = ["E", "W", "F", "C", "N", "R", "D", "H"]
+# Ignore W503, E501 because using black creates errors with this
+# Ignore D107 Missing docstring in __init__
+ignore = ["W503", "E501", "D107"]
+# D100, D101, D102, D103: Ignore missing docstrings in tests
+per-file-ignores = ["tests/*:D100,D101,D102,D103"]
+docstring-convention = "google"
+
+# Static analysis tools configuration
+[tool.mypy]
+exclude = "build"
+pretty = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+show_traceback = true
+show_error_codes = true
+namespace_packages = true
+explicit_package_bases = true
+check_untyped_defs = true
+
+# Ignore libraries that do not have type hint nor stubs
+[[tool.mypy.overrides]]
+module = [
+  "charms.operator_libs_linux.v2.snap",
+  "ops.*",
+]
+ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ops >= 2.4
+pyopenssl

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+
+"""MicroCloud charm."""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import time
+from typing import Dict, List, Union
+
+from charms.operator_libs_linux.v2.snap import SnapCache, SnapError, SnapState
+from charms.operator_libs_linux.v2.snap import install_local as snap_install_local
+from ops.charm import (
+    CharmBase,
+    ConfigChangedEvent,
+    InstallEvent,
+    RelationCreatedEvent,
+    RelationJoinedEvent,
+    StartEvent,
+    StopEvent,
+    UpdateStatusEvent,
+)
+from ops.framework import StoredState
+from ops.main import main
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    ModelError,
+    WaitingStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MaasMicroCloudCharm(CharmBase):
+    """MicroCloud charm class."""
+
+    _stored = StoredState()
+
+    def __init__(self, *args):
+        """Initialize charm's variable."""
+        super().__init__(*args)
+
+        # Initialize the persistent storage if needed
+        self._stored.set_default(
+            config={},
+            microcloud_binary_path="",
+            microcloud_snap_path="",
+        )
+
+        # Main event handlers
+        self.framework.observe(self.on.install, self._on_charm_install)
+        self.framework.observe(self.on.config_changed, self._on_charm_config_changed)
+        self.framework.observe(self.on.start, self._on_charm_start)
+        self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on.stop, self._on_charm_stop)
+
+        # Relation event handlers
+        self.framework.observe(self.on.cluster_relation_created, self._on_cluster_relation_created)
+        self.framework.observe(self.on.cluster_relation_joined, self._on_cluster_relation_joined)
+
+    @property
+    def peers(self):
+        """Fetch the cluster relation."""
+        return self.model.get_relation("cluster")
+
+    def get_peer_data_str(self, bag, key: str) -> str:
+        """Retrieve a str from the peer data bag."""
+        if not self.peers or not bag or not key:
+            return ""
+
+        value = self.peers.data[bag].get(key, "")
+        if isinstance(value, str):
+            return value
+
+        logger.error(f"Invalid data pulled out from {bag.name}.get('{key}')")
+        return ""
+
+    def set_peer_data_str(self, bag, key: str, value: str) -> None:
+        """Put a str into the peer data bag if not there or different."""
+        if not self.peers or not bag or not key:
+            return
+
+        old_value: str = self.get_peer_data_str(bag, key)
+        if old_value != value:
+            self.peers.data[bag][key] = value
+
+    def _on_charm_install(self, event: InstallEvent) -> None:
+        logger.info("Installing the MicroCloud charm")
+        # Confirm that the config is valid
+        if not self.config_is_valid():
+            return
+
+        # Install MicroCloud itself
+        try:
+            self.snap_install_microcloud()
+            logger.info("Microcloud installed successfully")
+        except RuntimeError:
+            logger.error("Failed to install MicroCloud")
+            event.defer()
+            return
+
+        # Apply side-loaded resources attached at deploy time
+        self.resource_sideload()
+
+    def _on_cluster_relation_created(self, event: RelationCreatedEvent) -> None:
+        """We must wait for all units to be ready before initializing MicroCloud."""
+        self.set_peer_data_str(self.unit, "clustered", "False")
+        return
+
+    def _on_charm_start(self, event: StartEvent) -> None:
+        logger.info("Starting the MicroCloud charm")
+
+        if self.config_changed():
+            logger.debug("Pending config changes detected")
+            self._on_charm_config_changed(event)
+
+        one_unit_clustered = False
+        for unit in self.peers.units:
+            if self.peers.data[unit].get("clustered") == "True":
+                one_unit_clustered = True
+                break
+
+        if one_unit_clustered:
+            # check if this unit has been clustered by the init process
+            try:
+                subprocess.run(
+                    ["lxc", "cluster", "list"],
+                    check=True,
+                    timeout=600,
+                )
+                self.set_peer_data_str(self.unit, "clustered", "True")
+                self.unit_active("Healthy MicroCloud unit")
+                return
+            except subprocess.CalledProcessError:
+                self.unit_waiting("This unit has not joined the cluster yet")
+                event.defer()
+                return
+            except subprocess.TimeoutExpired:
+                self.unit_blocked("This unit timed out checking its clustered status")
+                return
+
+        new_peers = [
+            self.peers.data[unit].get("clustered") == "False" for unit in self.peers.units
+        ]
+        if (
+            self.unit.is_leader()
+            and self.get_peer_data_str(self.unit, "clustered") == "False"
+            and all(new_peers)
+            and self.app.planned_units() == len(self.peers.units) + 1
+        ):
+            try:
+                self.microcloud_init()
+                self.set_peer_data_str(
+                    self.unit, "clustered", "True"
+                )  # This unit is sure to be clustered
+                # TODO: we can't say for sure that the cluster contains self.app.planned_units()
+                # some nodes might have failed to join the cluster but the command result
+                # is still a code 0. A workaround would be to parse the number of lines
+                # of `lxc cluster list -f csv` on this node.
+                self.unit_active("MicroCloud successfully initialized")
+                return
+            except RuntimeError as e:
+                logger.error(f"Failed to initialize MicroCloud: {e}")
+                self.unit_blocked("Failed to initialize MicroCloud")
+                return
+
+        time.sleep(10)  # Wait a bit before deferring the event
+
+        if self.unit.is_leader():
+            self.unit_waiting("Leader needs to wait for all units to be ready to bootstrap")
+        else:
+            self.unit_waiting("Unit needs to wait for all units to be ready to bootstrap")
+
+        event.defer()
+        return
+
+    def _on_update_status(self, event: UpdateStatusEvent) -> None:
+        """Regularly check if the unit is clustered."""
+        try:
+            subprocess.run(
+                ["lxc", "cluster", "list"],
+                check=True,
+                timeout=600,
+            )
+            self.set_peer_data_str(self.unit, "clustered", "True")
+            self.unit_active("Healthy MicroCloud unit")
+        except subprocess.CalledProcessError:
+            self.unit_blocked("This unit has failed to join the cluster")
+            return
+        except subprocess.TimeoutExpired:
+            self.unit_blocked("This unit timed out checking its clustered status")
+            return
+
+    def _on_charm_config_changed(self, event: Union[ConfigChangedEvent, StartEvent]) -> None:
+        """React to configuration changes. (JuJu refresh)."""
+        logger.info("Updating charm config")
+
+        # Confirm that the config is valid
+        if not self.config_is_valid():
+            return
+
+        # Get all the configs that changed
+        changed = self.config_changed()
+        if not changed:
+            logger.debug("No configuration changes to apply")
+            return
+        else:
+            if "microceph" in changed or "microovn" in changed:
+                logger.warning(
+                    "MicroCeph and MicroOVN can only be enabled / disabled at deploy time. Ignoring the changes"
+                )
+
+        # Apply all the configs that changed
+        try:
+            if (
+                "snap-channel-lxd" in changed
+                or "snap-channel-microcloud" in changed
+                or "snap-channel-microceph" in changed
+                or "snap-channel-microovn" in changed
+            ):
+                logger.info("Changes have been detected in the snap channels, updating the snaps")
+                self.snap_install_microcloud()
+        except RuntimeError:
+            msg = "Failed to apply some configuration change(s): %s" % ", ".join(changed)
+            self.unit_blocked(msg)
+            event.defer()
+            return
+
+    def _on_cluster_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Add a new node to the existing MicroCloud cluster."""
+        if (
+            self.unit.is_leader()
+            and self.get_peer_data_str(self.unit, "clustered") == "True"
+            and event.unit
+            != self.unit  # Don't add the leader to the cluster as it is already there
+        ):
+            try:
+                self.microcloud_add()
+                logger.info("New MicroCloud node successfully added")
+                return
+            except RuntimeError:
+                logger.error("Failed to add a new MicroCloud node")
+                return
+
+    def _on_charm_stop(self, event: StopEvent) -> None:
+        """Effectively remove this node from the existing MicroCloud cluster."""
+        if self.get_peer_data_str(self.unit, "clustered") == "True":
+            try:
+                self.microcloud_remove(os.uname().nodename)
+                logger.info("MicroCloud node successfully removed")
+            except RuntimeError:
+                logger.error("Failed to remove a MicroCloud node, retrying later")
+
+    def config_changed(self) -> Dict:
+        """Figure out what changed."""
+        new_config = self.config
+        old_config = self._stored.config
+        apply_config = {}
+        for k, v in new_config.items():
+            if k not in old_config:
+                apply_config[k] = v
+            elif v != old_config[k]:
+                apply_config[k] = v
+
+        return apply_config
+
+    def config_is_valid(self) -> bool:
+        """Validate the config."""
+        config_changed = self.config_changed()
+        logger.info(f"Validating config: {config_changed}")
+        return True
+
+    def microcloud_init(self) -> None:
+        """Apply initial configuration of MicroCloud."""
+        self.unit_maintenance("Initializing MicroCloud")
+
+        try:
+            microcloud_process_init = subprocess.run(
+                ["microcloud", "init", "--auto"],
+                capture_output=True,
+                check=True,
+                timeout=600,
+                text=True,
+            )
+
+            subprocess.run(
+                ["microceph", "enable", "rgw"],
+                check=True,
+                timeout=600,
+            )
+
+            logger.info(f"MicroCloud successfully initialized:\n{microcloud_process_init.stdout}")
+        except subprocess.CalledProcessError as e:
+            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            raise RuntimeError
+        except subprocess.TimeoutExpired as e:
+            self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+            raise RuntimeError
+
+    def microcloud_add(self) -> None:
+        """Add a new node to MicroCloud."""
+        self.unit_maintenance("Adding node to MicroCloud")
+
+        try:
+            microcloud_process_add = subprocess.run(
+                ["microcloud", "add", "--auto"],
+                capture_output=True,
+                check=True,
+                timeout=600,
+                text=True,
+            )
+            logger.info(f"MicroCloud node(s) successfully added:\n{microcloud_process_add.stdout}")
+        except subprocess.CalledProcessError as e:
+            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            raise RuntimeError
+        except subprocess.TimeoutExpired as e:
+            self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+            raise RuntimeError
+
+    def microcloud_remove(self, node_name_to_remove: str) -> None:
+        """Remove a node from MicroCloud."""
+        try:
+            # Check if instances are running on this node local storage
+            result = subprocess.run(
+                ["lxc", "list", "--all-projects", "--format=json"], capture_output=True, text=True
+            )
+            instances = json.loads(result.stdout)
+            for inst in instances:
+                if inst["location"] == node_name_to_remove:
+                    self.unit_blocked(
+                        "This Microcloud unit contains instances. You can't remove it."
+                    )
+                    return
+        except subprocess.CalledProcessError as e:
+            self.unit_blocked(
+                f"Failed to remove {node_name_to_remove} from the MicroCloud cluster: {e}"
+            )
+            raise RuntimeError
+        except subprocess.TimeoutExpired as e:
+            self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+            raise RuntimeError
+
+        self.unit_maintenance("Removing node from MicroCloud")
+
+        try:
+            # Let's remove the node from the LXD cluster as well because
+            # MicroCloud does not do it automatically for now.
+            # see here https://github.com/canonical/microcloud/issues/160
+            subprocess.run(
+                ["lxc", "cluster", "remove", node_name_to_remove],
+                capture_output=True,
+                check=True,
+                timeout=600,
+                text=True,
+            )
+
+            logger.info(
+                f"LXD cluster member successfully removed for the '{node_name_to_remove}' node"
+            )
+
+            # Same reason for MicroCeph: https://github.com/canonical/microcloud/issues/160
+            if self._stored.config["snap-channel-microceph"]:
+                subprocess.run(
+                    ["microceph", "cluster", "remove", node_name_to_remove],
+                    capture_output=True,
+                    check=True,
+                    timeout=600,
+                    text=True,
+                )
+
+                logger.info(
+                    f"MicroCeph cluster member successfully removed for the '{node_name_to_remove}' node"
+                )
+
+            # Same reason for microOVN: https://github.com/canonical/microcloud/issues/160
+            if self._stored.config["snap-channel-microovn"]:
+                subprocess.run(
+                    ["microovn", "cluster", "remove", node_name_to_remove],
+                    capture_output=True,
+                    check=True,
+                    timeout=600,
+                    text=True,
+                )
+
+                logger.info(
+                    f"MicroOVN cluster member successfully removed for the '{node_name_to_remove}' node"
+                )
+
+            # For now we don't check the status of ROLE. But in order to make it resilient,
+            # we'd need to introduce a ROLE check to make sure that the node is not
+            # in a PENDING state. see here
+            # https://github.com/canonical/microcloud/issues/161
+            subprocess.run(
+                ["microcloud", "cluster", "remove", node_name_to_remove],
+                capture_output=True,
+                check=True,
+                timeout=600,
+                text=True,
+            )
+
+            logger.info(
+                f"MicroCloud cluster member successfully removed for the '{node_name_to_remove}' node"
+            )
+
+        except subprocess.CalledProcessError as e:
+            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            raise RuntimeError
+        except subprocess.TimeoutExpired as e:
+            self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+            raise RuntimeError
+
+    def snap_install_microcloud(self) -> None:
+        """Install MicroCloud from snap."""
+        try:
+            cache = SnapCache()
+            cohort = "+"
+            snapd = cache["snapd"]  # Always refresh snapd first
+            snapd.ensure(SnapState.Latest, channel="stable")  # version 2.60.4
+
+            microcloud = cache["microcloud"]
+            if not microcloud.present:
+                microcloud.ensure(
+                    SnapState.Latest,
+                    channel=self.config["snap-channel-microcloud"],
+                    cohort=cohort,
+                )
+
+            microceph_enabled = self.config["microceph"]
+            if microceph_enabled:
+                microceph = cache["microceph"]
+                if not microceph.present:
+                    microceph.ensure(
+                        SnapState.Latest,
+                        channel=self.config["snap-channel-microceph"],
+                        cohort=cohort,
+                    )
+
+                subprocess.run(
+                    ["rm", "-rf", "/etc/ceph"],
+                    check=True,
+                    timeout=600,
+                )
+                subprocess.run(
+                    ["ln", "-s", "/var/snap/microceph/current/conf/", "/etc/ceph"],
+                    check=True,
+                    timeout=600,
+                )
+
+            microovn_enabled = self.config["microovn"]
+            if microovn_enabled:
+                microovn = cache["microovn"]
+                if not microovn.present:
+                    microovn.ensure(
+                        SnapState.Latest,
+                        channel=self.config["snap-channel-microovn"],
+                        cohort=cohort,
+                    )
+
+            lxd = cache["lxd"]
+            if (
+                not lxd.present
+            ):  # This should already be installed but let's refresh it just in case
+                lxd.ensure(
+                    SnapState.Latest, channel=self.config["snap-channel-lxd"], cohort=cohort
+                )
+        except SnapError as e:
+            logger.error(
+                "An exception occurred when installing snap packages. Reason: %s", e.message
+            )
+            self.unit_blocked("An exception occurred when installing snap packages")
+            raise RuntimeError
+
+        # Done with the snap installation
+        self._stored.config["snap-channel-lxd"] = self.config["snap-channel-lxd"]
+        self._stored.config["snap-channel-microcloud"] = self.config["snap-channel-microcloud"]
+        self._stored.config["snap-channel-microceph"] = self.config["snap-channel-microceph"]
+        self._stored.config["snap-channel-microovn"] = self.config["snap-channel-microovn"]
+
+    def microcloud_reload(self) -> None:
+        """Reload the microcloud daemon."""
+        self.unit_maintenance("Reloading MicroCloud")
+        try:
+            # Avoid occasional race during startup where a reload could cause a failure
+            subprocess.run(
+                ["microcloud", "waitready", "--timeout=30"], capture_output=True, check=False
+            )
+
+            cache = SnapCache()
+            microcloud = cache["microcloud"]
+            if microcloud.present:
+                microcloud.restart(reload=True)
+
+        except subprocess.CalledProcessError as e:
+            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            raise RuntimeError
+
+    def resource_sideload(self) -> None:
+        """Side-load resources."""
+        # Multi-arch support
+        arch: str = os.uname().machine
+        possible_archs: List[str] = [arch]
+        if arch == "x86_64":
+            possible_archs = ["x86_64", "amd64"]
+
+        # Microcloud snap
+        microcloud_snap_resource: str = ""
+        fname_suffix: str = ".snap"
+        try:
+            # Note: self._stored can only store simple data types (int/float/dict/list/etc)
+            microcloud_snap_resource = str(self.model.resources.fetch("microcloud-snap"))
+        except ModelError:
+            pass
+
+        tmp_dir: str = ""
+        if microcloud_snap_resource and tarfile.is_tarfile(microcloud_snap_resource):
+            logger.debug(f"{microcloud_snap_resource} is a tarball; unpacking")
+            tmp_dir = tempfile.mkdtemp()
+            tarball = tarfile.open(microcloud_snap_resource)
+            valid_names = {f"microcloud_{x}{fname_suffix}" for x in possible_archs}
+            for f in valid_names.intersection(tarball.getnames()):
+                tarball.extract(f, path=tmp_dir)
+                logger.debug(f"{f} was extracted from the tarball")
+                self._stored.lxd_snap_path = f"{tmp_dir}/{f}"
+                break
+            else:
+                logger.debug("Missing arch specific snap from tarball")
+            tarball.close()
+        else:
+            self._stored.microcloud_snap_path = microcloud_snap_resource
+
+        if self._stored.microcloud_snap_path:
+            self.snap_sideload_microcloud()
+            if tmp_dir:
+                os.remove(self._stored.microcloud_snap_path)
+                os.rmdir(tmp_dir)
+
+        # MicroCloud binary
+        microcloud_binary_resource: str = ""
+        fname_suffix = ""
+        try:
+            # Note: self._stored can only store simple data types (int/float/dict/list/etc)
+            microcloud_binary_resource = str(self.model.resources.fetch("microcloud-binary"))
+        except ModelError:
+            pass
+
+        tmp_dir = ""
+        if microcloud_binary_resource and tarfile.is_tarfile(microcloud_binary_resource):
+            logger.debug(f"{microcloud_binary_resource} is a tarball; unpacking")
+            tmp_dir = tempfile.mkdtemp()
+            tarball = tarfile.open(microcloud_binary_resource)
+            valid_names = {f"microcloud_{x}{fname_suffix}" for x in possible_archs}
+            for f in valid_names.intersection(tarball.getnames()):
+                tarball.extract(f, path=tmp_dir)
+                logger.debug(f"{f} was extracted from the tarball")
+                self._stored.microcloud_binary_path = f"{tmp_dir}/{f}"
+                break
+            else:
+                logger.debug("Missing arch specific binary from tarball")
+            tarball.close()
+        else:
+            self._stored.microcloud_binary_path = microcloud_binary_resource
+
+        if self._stored.microcloud_binary_path:
+            self.snap_sideload_microcloud_binary()
+            if tmp_dir:
+                os.remove(self._stored.microcloud_binary_path)
+                os.rmdir(tmp_dir)
+
+    def snap_sideload_microcloud(self) -> None:
+        """Side-load MicroCloud snap resource."""
+        logger.debug("Applying MicroCloud snap side-load changes")
+
+        # A 0 byte file will unload the resource
+        if os.path.getsize(self._stored.microcloud_snap_path) == 0:
+            logger.debug("Reverting to MicroCloud snap from snap store")
+            channel: str = self._stored.config["snap-channel-microcloud"]
+            try:
+                cache = SnapCache()
+                microcloud = cache["microcloud"]
+                microcloud.ensure(SnapState.Latest, channel=channel)
+            except SnapError as e:
+                self.unit_blocked(f"Failed to refresh the MicroCloud snap: {e.message}")
+                raise RuntimeError
+
+        else:
+            logger.debug("Side-loading MicroCloud snap")
+            try:
+                snap_install_local(self._stored.microcloud_snap_path, dangerous=True)
+            except SnapError as e:
+                self.unit_blocked(f"Failed to side-load MicroCloud snap: {e.message}")
+                raise RuntimeError
+
+            try:
+                # Since the side-loaded snap doesn't have an assertion, some things need
+                # to be done manually
+                subprocess.run(
+                    ["systemctl", "enable", "--now", "snap.microcloud.daemon.unix.socket"],
+                    capture_output=True,
+                    check=True,
+                    timeout=600,
+                )
+            except subprocess.CalledProcessError as e:
+                self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+                raise RuntimeError
+            except subprocess.TimeoutExpired as e:
+                self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+                raise RuntimeError
+
+    def snap_sideload_microcloud_binary(self) -> None:
+        """Side-load MicroCloud binary resource."""
+        logger.debug("Applying MicroCloud binary side-load changes")
+        microcloud_debug: str = "/var/snap/microcloud/common/microcloud.debug"
+
+        # A 0 byte file will unload the resource
+        if os.path.getsize(self._stored.lxd_binary_path) == 0:
+            logger.debug("Unloading side-loaded MicroCloud binary")
+            if os.path.exists(microcloud_debug):
+                os.remove(microcloud_debug)
+        else:
+            logger.debug("Side-loading MicroCloud binary")
+            # Avoid "Text file busy" error
+            if os.path.exists(microcloud_debug):
+                logger.debug("Removing old side-loaded LXD binary")
+                os.remove(microcloud_debug)
+            shutil.copyfile(self._stored.microcloud_binary_path, microcloud_debug)
+            os.chmod(microcloud_debug, 0o755)
+
+        self.microcloud_reload()
+
+    def unit_active(self, msg: str = "") -> None:
+        """Set the unit's status to active and log the provided message, if any."""
+        self.unit.status = ActiveStatus()
+        if msg:
+            logger.debug(msg)
+
+    def unit_blocked(self, msg: str) -> None:
+        """Set the unit's status to blocked and log the provided message."""
+        self.unit.status = BlockedStatus(msg)
+        logger.error(msg)
+
+    def unit_maintenance(self, msg: str) -> None:
+        """Set the unit's status to maintenance and log the provided message."""
+        self.unit.status = MaintenanceStatus(msg)
+        logger.info(msg)
+
+    def unit_waiting(self, msg: str) -> None:
+        """Set the unit's status to waiting and log the provided message."""
+        self.unit.status = WaitingStatus(msg)
+        logger.info(msg)
+
+
+if __name__ == "__main__":
+    main(MaasMicroCloudCharm)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,59 @@
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = lint, static
+
+[vars]
+src_path = {toxinidir}/src/
+#tst_path = {toxinidir}/tests/
+#all_path = {[vars]src_path} {[vars]tst_path}
+all_path = {[vars]src_path}
+
+[testenv]
+basepython = python3
+setenv =
+    PYTHONPATH = {[vars]src_path}
+    PY_COLORS=1
+passenv =
+    PYTHONPATH
+    HOME
+    PATH
+    MODEL_SETTINGS
+
+[testenv:fmt]
+description = Apply coding style standards to code
+deps =
+    black
+    isort
+commands =
+    isort {[vars]all_path}
+    black {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+    black
+    flake8
+    flake8-docstrings
+    flake8-builtins
+    pyproject-flake8
+    pep8-naming
+    isort
+commands =
+    # pflake8 wrapper suppports config from pyproject.toml
+    pflake8 {[vars]all_path}
+    isort --check-only --diff {[vars]all_path}
+    black --check --diff {[vars]all_path}
+
+[testenv:static]
+description = Run static analysis checks
+deps =
+    mypy
+    types-PyYAML
+    pytest
+    pytest-operator
+    juju
+    types-setuptools
+    types-toml
+commands =
+    mypy {[vars]all_path} {posargs}


### PR DESCRIPTION
This is the initial work for the Microcloud MAAS charm. 

**As of now the charm achieves the following**:
* Support for `microceph` and `microovn`.
* A cluster is bootstraped with the microcloud `--auto` flag.
* Three nodes and four nodes cluster initialization (I didn't test for bigger configurations because of hardware limitations but I don't see any systemic code issues that wouldn't allow it)
* One unit at a time scale-up: 3 to 4 scale-up tested successfully

**Roadmap items to achieve for 0.2**:
* ~~https://github.com/canonical/charm-microcloud/issues/3~~
* https://github.com/canonical/charm-microcloud/issues/4
* https://github.com/canonical/charm-microcloud/issues/5

**Roadmap items to achieve for 1.0**:
* https://github.com/canonical/charm-microcloud/issues/6
* https://github.com/canonical/charm-microcloud/issues/7

Closes #3