### PR TITLE
charm: Fix typo for stored state variables

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -526,7 +526,7 @@ class MaasMicroCloudCharm(CharmBase):
             for f in valid_names.intersection(tarball.getnames()):
                 tarball.extract(f, path=tmp_dir)
                 logger.debug(f"{f} was extracted from the tarball")
-                self._stored.lxd_snap_path = f"{tmp_dir}/{f}"
+                self._stored.microcloud_snap_path = f"{tmp_dir}/{f}"
                 break
             else:
                 logger.debug("Missing arch specific snap from tarball")
@@ -618,7 +618,7 @@ class MaasMicroCloudCharm(CharmBase):
         microcloud_debug: str = "/var/snap/microcloud/common/microcloud.debug"
 
         # A 0 byte file will unload the resource
-        if os.path.getsize(self._stored.lxd_binary_path) == 0:
+        if os.path.getsize(self._stored.microcloud_binary_path) == 0:
             logger.debug("Unloading side-loaded MicroCloud binary")
             if os.path.exists(microcloud_debug):
                 os.remove(microcloud_debug)


### PR DESCRIPTION
The charm allows using resources to sideload a custom MicroCloud binary and snap. Those infos are stored in the state and need to be referenced using the right key.

Currently this is breaking the charm installation with the following error when using custom resources (happens when installing from charmhub using the 0 byte resources):

```
2023-11-13 11:55:10 ERROR unit.microcloud/10.juju-log server.go:325 Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-microcloud-10/charm/./src/charm.py", line 659, in <module>
    main(MaasMicroCloudCharm)
  File "/var/lib/juju/agents/unit-microcloud-10/charm/venv/ops/main.py", line 436, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-microcloud-10/charm/venv/ops/main.py", line 144, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-microcloud-10/charm/venv/ops/framework.py", line 340, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-microcloud-10/charm/venv/ops/framework.py", line 842, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-microcloud-10/charm/venv/ops/framework.py", line 931, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-microcloud-10/charm/./src/charm.py", line 109, in _on_charm_install
    self.resource_sideload()
  File "/var/lib/juju/agents/unit-microcloud-10/charm/./src/charm.py", line 570, in resource_sideload
    self.snap_sideload_microcloud_binary()
  File "/var/lib/juju/agents/unit-microcloud-10/charm/./src/charm.py", line 621, in snap_sideload_microcloud_binary
    if os.path.getsize(self._stored.lxd_binary_path) == 0:
  File "/var/lib/juju/agents/unit-microcloud-10/charm/venv/ops/framework.py", line 1081, in __getattr__
    raise AttributeError(f"attribute '{key}' is not stored")
AttributeError: attribute 'lxd_binary_path' is not stored
```